### PR TITLE
Use icon textures for TicTacToe board

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -4,6 +4,10 @@ var board = ["", "", "", "", "", "", "", "", ""]
 var player_turn = true
 var game_over = false
 
+# Textures for prettier board rendering
+var cross_texture: Texture2D = preload("res://cross.svg")
+var circle_texture: Texture2D = preload("res://circle.svg")
+
 func pythonpath():
 	var output: Array = []
 	var exit_code = OS.execute("where", ["python"], output, true)
@@ -108,12 +112,21 @@ func update_ui():
 	else:
 		print("Parsing JSON error:", output[0])
 	
-	for i in range(9):
-		var cell = get_node("GridContainer/Cell" + str(i))
-		if cell != null:
-			cell.text = board[i]
-		else:
-			print("Cell", i, " not found!")
+       for i in range(9):
+               var cell = get_node("GridContainer/Cell" + str(i))
+               if cell != null:
+                        match board[i]:
+                                "X":
+                                        cell.icon = cross_texture
+                                        cell.text = ""
+                                "O":
+                                        cell.icon = circle_texture
+                                        cell.text = ""
+                                _:
+                                        cell.icon = null
+                                        cell.text = ""
+               else:
+                       print("Cell", i, " not found!")
 	
 	check_winner()
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Traditional games rely on local logic and are hard to verify. By moving the game
 ## Running the Game
 
 1. Open the project in Godot and press **Play**.
-2. When you click a cell, the project calls the Python scripts in `xsolla-zk-lib/` to start the game, make a move and refresh the board.
+2. When you click a cell, the project calls the Python scripts in `xsolla-zk-lib/` to start the game, make a move and refresh the board. The board now uses vector images (`cross.svg` and `circle.svg`) instead of plain text for a cleaner look.
 
 You can also run the Python helpers directly from the command line if desired:
 

--- a/circle.svg
+++ b/circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="24" stroke="blue" stroke-width="8" fill="none"/>
+</svg>

--- a/cross.svg
+++ b/cross.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <line x1="16" y1="16" x2="48" y2="48" stroke="red" stroke-width="8" stroke-linecap="round"/>
+  <line x1="48" y1="16" x2="16" y2="48" stroke="red" stroke-width="8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- show tic‑tac‑toe marks using images
- mention new board icons in the README

## Testing
- `python -m py_compile xsolla-zk-lib/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684147f31914832c8af5e2c82704149d